### PR TITLE
Replace app with static slide generator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+node_modules
+.DS_Store
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+.env.local
+.env.*.local
+
+# Build outputs
+dist

--- a/index.html
+++ b/index.html
@@ -1,0 +1,56 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Quick Slides</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <header class="topbar">
+    <h1>Quick Slides</h1>
+    <div class="actions">
+      <button id="generateBtn">Generate slides</button>
+      <button id="presentBtn">Start presentation</button>
+      <button id="prevBtn" title="Arrow Left">◀</button>
+      <button id="nextBtn" title="Arrow Right">▶</button>
+      <button id="pdfBtn">Export PDF</button>
+      <select id="themeSelect" aria-label="Theme">
+        <option value="light">Light</option>
+        <option value="dark">Dark</option>
+        <option value="clean">Clean</option>
+      </select>
+    </div>
+  </header>
+
+  <main class="layout">
+    <section class="editor">
+      <label for="inputText"><strong>Paste your content here.</strong>
+        Each blank line or a line with three dashes --- starts a new slide.</label>
+      <textarea id="inputText" spellcheck="false" placeholder="Example:
+Title slide
+
+Problem
+Buyers cannot see signal in noise.
+
+---
+Solution
+AI agents turn messy data into decisions.
+
+---
+Call to action
+Email chris@company.com"></textarea>
+    </section>
+
+    <section class="stage">
+      <div id="slides" class="slides"></div>
+    </section>
+  </main>
+
+  <footer class="foot">
+    <small>Tip: Use Left and Right arrow keys in presentation. Content is stored locally in your browser.</small>
+  </footer>
+
+  <script src="script.js"></script>
+</body>
+</html>

--- a/readme.md
+++ b/readme.md
@@ -1,2 +1,0 @@
-# chatgptfun
-First commit 🚀

--- a/script.js
+++ b/script.js
@@ -1,0 +1,112 @@
+const input = document.getElementById("inputText");
+const slidesEl = document.getElementById("slides");
+const generateBtn = document.getElementById("generateBtn");
+const presentBtn = document.getElementById("presentBtn");
+const pdfBtn = document.getElementById("pdfBtn");
+const prevBtn = document.getElementById("prevBtn");
+const nextBtn = document.getElementById("nextBtn");
+const themeSelect = document.getElementById("themeSelect");
+
+let slides = [];
+let current = 0;
+
+const STORAGE_KEY = "quick-slides-input";
+input.value = localStorage.getItem(STORAGE_KEY) || input.value;
+input.addEventListener("input", () => localStorage.setItem(STORAGE_KEY, input.value));
+
+function parseSlides(text) {
+  // Split on blank lines or lines that are exactly '---'
+  const raw = text.split(/\n\s*\n|^\s*---\s*$/m).map(s => s.trim()).filter(Boolean);
+  return raw.map(block => {
+    const lines = block.split("\n").map(l => l.trim()).filter(Boolean);
+    const title = lines.shift() || "";
+    return { title, bullets: lines };
+  });
+}
+
+function renderSlides() {
+  slidesEl.innerHTML = "";
+  slides.forEach((s, i) => {
+    const card = document.createElement("div");
+    card.className = "slide";
+    const h = document.createElement("h2");
+    h.textContent = s.title;
+    card.appendChild(h);
+    s.bullets.forEach(b => {
+      const p = document.createElement("p");
+      p.textContent = b;
+      card.appendChild(p);
+    });
+    const n = document.createElement("div");
+    n.className = "num";
+    n.textContent = `${i + 1}/${slides.length}`;
+    card.appendChild(n);
+    slidesEl.appendChild(card);
+  });
+}
+
+function startPresentation() {
+  if (!slides.length) generate();
+  document.documentElement.classList.add("present");
+  current = 0;
+  showCurrent();
+}
+
+function endPresentation() {
+  document.documentElement.classList.remove("present");
+}
+
+function showCurrent() {
+  const cards = [...document.querySelectorAll(".slide")];
+  cards.forEach((c, i) => {
+    c.style.display = (document.documentElement.classList.contains("present"))
+      ? (i === current ? "flex" : "none")
+      : "flex";
+  });
+}
+
+function next() {
+  if (current < slides.length - 1) { current++; showCurrent(); }
+}
+function prev() {
+  if (current > 0) { current--; showCurrent(); }
+}
+
+function exportPDF() {
+  // Use the browser print dialog. Print styles make one slide per page.
+  window.print();
+}
+
+function applyTheme(name) {
+  document.documentElement.classList.remove("theme-dark", "theme-clean");
+  if (name === "dark") document.documentElement.classList.add("theme-dark");
+  if (name === "clean") document.documentElement.classList.add("theme-clean");
+  localStorage.setItem("quick-slides-theme", name);
+}
+
+function generate() {
+  slides = parseSlides(input.value);
+  renderSlides();
+  showCurrent();
+}
+
+generateBtn.addEventListener("click", generate);
+presentBtn.addEventListener("click", () => {
+  if (document.documentElement.classList.contains("present")) endPresentation();
+  else startPresentation();
+});
+pdfBtn.addEventListener("click", exportPDF);
+nextBtn.addEventListener("click", next);
+prevBtn.addEventListener("click", prev);
+document.addEventListener("keydown", e => {
+  if (e.key === "ArrowRight") next();
+  if (e.key === "ArrowLeft") prev();
+  if (e.key === "Escape") endPresentation();
+});
+
+themeSelect.value = localStorage.getItem("quick-slides-theme") || "light";
+applyTheme(themeSelect.value);
+themeSelect.addEventListener("change", e => applyTheme(e.target.value));
+
+// Initial render
+generate();

--- a/style.css
+++ b/style.css
@@ -1,0 +1,70 @@
+:root {
+  --bg: #ffffff;
+  --fg: #111111;
+  --muted: #666;
+  --accent: #2b59ff;
+}
+
+* { box-sizing: border-box; }
+html, body { height: 100%; }
+body {
+  margin: 0;
+  font-family: -apple-system, system-ui, Segoe UI, Roboto, Helvetica, Arial, sans-serif;
+  color: var(--fg);
+  background: var(--bg);
+}
+
+.topbar {
+  display: flex; align-items: center; justify-content: space-between;
+  padding: 10px 16px; border-bottom: 1px solid #e6e6e6; position: sticky; top: 0; background: var(--bg); z-index: 5;
+}
+.topbar h1 { font-size: 18px; margin: 0; }
+.actions { display: flex; gap: 8px; flex-wrap: wrap; }
+button, select {
+  padding: 8px 12px; border: 1px solid #d0d0d0; background: #fff; cursor: pointer; border-radius: 8px;
+}
+button:hover { border-color: var(--accent); }
+
+.layout { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; padding: 16px; }
+.editor textarea {
+  width: 100%; height: 60vh; padding: 12px; font-size: 15px; border-radius: 12px;
+  border: 1px solid #ddd; resize: vertical; line-height: 1.5;
+}
+
+.stage {
+  border: 1px solid #eee; border-radius: 12px; padding: 8px; background: #fafafa; height: 100%;
+}
+.slides {
+  display: grid; grid-auto-rows: 60vh; gap: 12px; overflow: auto; padding: 8px;
+}
+.slide {
+  background: var(--bg); color: var(--fg); border: 1px solid #e6e6e6; border-radius: 16px;
+  display: flex; align-items: center; justify-content: center; padding: 6vh 6vw; position: relative;
+}
+.slide h2 { font-size: clamp(28px, 6vw, 52px); margin: 0 0 8px 0; }
+.slide p  { font-size: clamp(18px, 3vw, 26px); margin: 4px 0; line-height: 1.35; }
+.slide .num { position: absolute; right: 14px; bottom: 10px; color: var(--muted); font-size: 12px; }
+
+/* Presentation mode */
+.present body { overflow: hidden; }
+.present .layout { display: block; padding: 0; }
+.present .stage { border: 0; padding: 0; background: var(--bg); }
+.present .slides { height: 100vh; width: 100vw; display: block; }
+.present .slide {
+  height: 100vh; width: 100vw; border: 0; border-radius: 0; margin: 0; padding: 10vh 10vw;
+}
+
+/* Themes */
+.theme-dark { --bg: #0b0f1a; --fg: #f5f7ff; --muted: #a7b1c0; --accent: #7aa2ff; }
+.theme-clean { --bg: #fff; --fg: #111; --muted: #888; --accent: #111; }
+
+/* Print to PDF */
+@media print {
+  @page { size: A4 landscape; margin: 0; }
+  body { background: #fff; }
+  .topbar, .foot { display: none !important; }
+  .layout { display: block; padding: 0; }
+  .slides { display: block; padding: 0; }
+  .slide { page-break-after: always; height: 100vh; width: 100vw; border: 0; border-radius: 0; }
+}
+.foot { padding: 8px 16px; color: var(--muted); border-top: 1px solid #eee; }


### PR DESCRIPTION
## Summary
- remove the previous React/Vite project structure
- add a static HTML slide generator with textarea input and preview
- implement standalone CSS styling and JavaScript for theming, presentation mode, and PDF export

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68da4f27567883299a2a84e77dd99d28