### PR TITLE
Make AI drafting auto-apply and fix assistant contrast

### DIFF
--- a/script.js
+++ b/script.js
@@ -307,10 +307,21 @@ async function handleDraft() {
   if (!prompt) return;
   aiDraftBtn.disabled = true;
   aiDraftBtn.textContent = "Drafting…";
-  aiDrafts = await aiService.draftSlides({ prompt });
-  renderSuggestions(aiDrafts);
-  aiDraftBtn.disabled = false;
-  aiDraftBtn.textContent = "Draft slides";
+  try {
+    aiDrafts = await aiService.draftSlides({ prompt });
+    if (aiDrafts.length) {
+      slides = aiDrafts.map(slide => ({ title: slide.title, bullets: slide.bullets }));
+      current = 0;
+      renderSlides();
+      showCurrent();
+      updateInputFromSlides();
+      persistDeck();
+    }
+    renderSuggestions(aiDrafts);
+  } finally {
+    aiDraftBtn.disabled = false;
+    aiDraftBtn.textContent = "Draft slides";
+  }
 }
 
 function applyTone() {

--- a/style.css
+++ b/style.css
@@ -204,9 +204,17 @@ select {
   width: 100%;
   padding: 10px 12px;
   border-radius: 12px;
-  border: 1px solid rgba(52, 84, 255, 0.2);
-  background: #ffffff;
+  border: 1px solid var(--input-border);
+  background: var(--input-bg);
+  color: var(--fg);
   box-shadow: 0 10px 20px rgba(52, 84, 255, 0.1);
+  transition: border 180ms ease, box-shadow 200ms ease, background 200ms ease, color 200ms ease;
+}
+
+.ai-tools textarea::placeholder,
+.ai-tools input[type="text"]::placeholder {
+  color: var(--muted);
+  opacity: 0.7;
 }
 
 .ai-actions,


### PR DESCRIPTION
## Summary
- update AI assistant inputs to respect the active theme for clear text contrast
- automatically populate the deck with AI-generated slides after drafting from a story prompt while retaining suggestions

## Testing
- Manual via browser_container: loaded index.html, switched to dark theme, filled AI prompt, confirmed text visibility

------
https://chatgpt.com/codex/tasks/task_e_68dbc57152a4832980663592e34471e0