### PR TITLE
Reset deck state on navigation

### DIFF
--- a/src/services/collab.js
+++ b/src/services/collab.js
@@ -105,6 +105,18 @@ export class CollaborationService extends EventTarget {
     return `${COMMENT_PREFIX}${this.deckId}`;
   }
 
+  clearDeck(deckId = this.deckId) {
+    const id = deckId;
+    if (!id) return;
+    try {
+      localStorage.removeItem(`${STORAGE_PREFIX}${id}`);
+      localStorage.removeItem(`${HISTORY_PREFIX}${id}`);
+      localStorage.removeItem(`${COMMENT_PREFIX}${id}`);
+    } catch (error) {
+      console.warn("Failed to clear deck storage", error);
+    }
+  }
+
   loadDeck() {
     if (!this.deckId) return undefined;
     return readLocal(this.deckKey, undefined);

--- a/style.css
+++ b/style.css
@@ -270,6 +270,61 @@ select {
   padding: 12px;
 }
 
+.slides-empty {
+  min-height: 60vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  gap: 12px;
+  padding: 48px 32px;
+  border-radius: 26px;
+  border: 2px dashed rgba(52, 84, 255, 0.35);
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.86) 0%, rgba(255, 255, 255, 0.65) 100%);
+  box-shadow: inset 0 0 0 1px rgba(52, 84, 255, 0.08), 0 22px 40px rgba(15, 23, 42, 0.08);
+  color: var(--muted);
+}
+
+.slides-empty h2 {
+  margin: 0;
+  font-size: clamp(26px, 4vw, 40px);
+  color: var(--fg);
+}
+
+.slides-empty p {
+  margin: 0;
+  max-width: 420px;
+  line-height: 1.5;
+}
+
+.empty-icon {
+  font-size: clamp(42px, 8vw, 72px);
+  filter: drop-shadow(0 12px 24px rgba(52, 84, 255, 0.25));
+}
+
+.empty-hint {
+  font-size: 14px;
+  color: var(--muted);
+  background: rgba(52, 84, 255, 0.12);
+  padding: 8px 14px;
+  border-radius: 999px;
+}
+
+.slides-empty kbd {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 4px 10px;
+  border-radius: 6px;
+  border: 1px solid rgba(28, 33, 64, 0.18);
+  background: #fff;
+  font-size: 12px;
+  font-weight: 600;
+  box-shadow: 0 6px 12px rgba(15, 23, 42, 0.08);
+  margin: 0 4px;
+}
+
 .slide {
   background: var(--slide-bg);
   color: var(--fg);


### PR DESCRIPTION
## Summary
- clear persisted deck content when no share link is present and reset the experience after navigating back to the page
- add a helper on the collaboration service to remove stored decks and reuse it for resets
- refresh the slides stage with an empty-state design to guide users when no slides exist

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dc140e2e9883298e9568694e2b7460